### PR TITLE
Update link in requests section

### DIFF
--- a/source/guides/guides/network-requests.md
+++ b/source/guides/guides/network-requests.md
@@ -114,7 +114,7 @@ Cypress automatically indicates when an XHR request happens in your application.
 
 ![snapshot_request](https://user-images.githubusercontent.com/1271364/26947393-930508b0-4c60-11e7-90a0-4d42ee3f24c0.gif)
 
-By default, Cypress is configured to *ignore* requests that are used to fetch static content like `.js` or `.html` files. This keeps the Command Log less noisy. This option can be changed in the {% url 'configuration' configuration %}.
+By default, Cypress is configured to *ignore* requests that are used to fetch static content like `.js` or `.html` files. This keeps the Command Log less noisy. This option can be changed by overriding the default whitelisting in the {% url '`cy.server()` options' server#Options %}.
 
 Cypress automatically collects the request `headers` and the request `body` and will make this available to you.
 


### PR DESCRIPTION
Update the 'Requests' section regarding Cypress default behavior of ignoring requests that fetch static files. Change link to direct to documentation for cy.server() options.whitelist. Not sure if this is also configurable elsewhere...I just didn't find anything in the configuration page that is currently linked to.

<!--
Thanks for contributing!

Please explain what changes were made and also
reference any issues that were fixed with #[ISSUE]
-->
